### PR TITLE
Feat: 위험 라인 검출, 위험 라인 넘어갈 시 무게중심 색 변화

### DIFF
--- a/app/src/main/java/com/google/mediapipe/examples/poselandmarker/BedConnerDetection.java
+++ b/app/src/main/java/com/google/mediapipe/examples/poselandmarker/BedConnerDetection.java
@@ -10,8 +10,9 @@ import org.opencv.imgproc.Imgproc;
 import android.graphics.Bitmap;
 
 public class BedConnerDetection {
-    private static final int DESIRED_ANGLE = 60;
+    private static final int DESIRED_ANGLE = 70;
     private static final int MARGIN_OF_ERROR = 20;
+    private static final float RATE_OF_DANGER = (float) 0.3;
 
     private static final double tan_pos_angle = Math.tan(Math.toRadians(DESIRED_ANGLE));
     private static final double tan_neg_angle = Math.tan(Math.toRadians(-DESIRED_ANGLE));
@@ -35,6 +36,8 @@ public class BedConnerDetection {
 
     private static float normalizedLx1, normalizedLy1, normalizedLx2, normalizedLy2;
     private static float normalizedRx1, normalizedRy1, normalizedRx2, normalizedRy2;
+    private static float dangerLx1, dangerLy1, dangerLx2, dangerLy2;
+    private static float dangerRx1, dangerRy1, dangerRx2, dangerRy2;
 
     public double getLx1() {
         return lx1;
@@ -100,6 +103,39 @@ public class BedConnerDetection {
         return normalizedRy2;
     }
 
+    // 위험
+    public float getDangerLx1() {
+        return dangerLx1;
+    }
+
+    public float getDangerLy1() {
+        return dangerLy1;
+    }
+
+    public float getDangerLx2() {
+        return dangerLx2;
+    }
+
+    public float getDangerLy2() {
+        return dangerLy2;
+    }
+
+    public float getDangerRx1() {
+        return dangerRx1;
+    }
+
+    public float getDangerRy1() {
+        return dangerRy1;
+    }
+
+    public float getDangerRx2() {
+        return dangerRx2;
+    }
+
+    public float getDangerRy2() {
+        return dangerRy2;
+    }
+
     public Bitmap detectBedBorders(Bitmap bitmap) {
         bmpWidth = bitmap.getWidth();
         bmpHeight = bitmap.getHeight();
@@ -110,8 +146,11 @@ public class BedConnerDetection {
         Mat gray = new Mat();
         Imgproc.cvtColor(frame, gray, Imgproc.COLOR_BGR2GRAY);
 
+        Mat blur = new Mat();
+        Imgproc.bilateralFilter(gray, blur, 10, 75, 75);
+
         Mat edges = new Mat();
-        Imgproc.Canny(gray, edges, 50, 150);
+        Imgproc.Canny(blur, edges, 50, 150);
 
         int height = edges.rows();
         int width = edges.cols();
@@ -121,33 +160,45 @@ public class BedConnerDetection {
 
 
         MatOfInt4 left_lines = new MatOfInt4();
-        Imgproc.HoughLinesP(left_half, left_lines, 1, Math.PI/180, 40, 40, 10);
+        Imgproc.HoughLinesP(left_half, left_lines, 1, Math.PI/180, 40, 60, 10);
+        double maxL = 0.0f;
         for (int i = 0; i < left_lines.rows(); i++) {
             double[] vec = left_lines.get(i, 0);
             double x1 = vec[0], y1 = vec[1], x2 = vec[2], y2 = vec[3];
             double m = (y2 - y1) / (x2 - x1);
 
             if (tan_neg_lower_margin < m && m < tan_neg_upper_margin) {
-                lx1 = x1 - y1 / m;
-                ly1 = 0;
-                lx2 = x1 + (height - y1) / m;
-                ly2 = height;
+
+                double distanceN = Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
+                if (maxL < distanceN) {
+                    lx1 = x1 - y1 / m;
+                    ly1 = 0;
+                    lx2 = x1 + (height - y1) / m;
+                    ly2 = height;
+                    maxL = distanceN;
+                }
                 //Imgproc.line(frame, start, end, new Scalar(0, 0, 255), 4);
             }
         }
 
         MatOfInt4 right_lines = new MatOfInt4();
-        Imgproc.HoughLinesP(right_half, right_lines, 1, Math.PI/180, 40, 40, 10);
+        Imgproc.HoughLinesP(right_half, right_lines, 1, Math.PI/180, 40, 60, 10);
+        maxL = 0.0f;
         for (int i = 0; i < right_lines.rows(); i++) {
             double[] vec = right_lines.get(i, 0);
             double x1 = vec[0] + width/2, y1 = vec[1], x2 = vec[2] + width/2, y2 = vec[3];
             double m = (y2 - y1) / (x2 - x1);
 
             if (tan_pos_lower_margin < m && m < tan_pos_upper_margin) {
-                rx1 = x1 - y1 / m;
-                ry1 = 0;
-                rx2 = x1 + (height - y1) / m;
-                ry2 = height;
+
+                double distanceN = Math.sqrt(Math.pow(x2 - x1, 2) + Math.pow(y2 - y1, 2));
+                if (maxL < distanceN) {
+                    rx1 = x1 - y1 / m;
+                    ry1 = 0;
+                    rx2 = x1 + (height - y1) / m;
+                    ry2 = height;
+                    maxL = distanceN;
+                }
                 //Imgproc.line(frame, start, end, new Scalar(0, 0, 255), 4);
             }
 
@@ -161,6 +212,19 @@ public class BedConnerDetection {
             normalizedRy1 = (float) (ry1 / bmpHeight);
             normalizedRx2 = (float) (rx2 / bmpWidth);
             normalizedRy2 = (float) (ry2 / bmpHeight);
+
+
+            // 위험 영역
+            dangerLx1 = normalizedLx1+(normalizedRx1 - normalizedLx1)*(RATE_OF_DANGER/2);
+            dangerLx2 = normalizedLx2+(normalizedRx2 - normalizedLx2)*(RATE_OF_DANGER/2);
+            dangerLy1 = normalizedLy1;
+            dangerLy2 = normalizedLy2;
+
+            dangerRx1 = normalizedRx1-(normalizedRx1 - normalizedLx1)*(RATE_OF_DANGER/2);
+            dangerRx2 = normalizedRx2-(normalizedRx2 - normalizedLx2)*(RATE_OF_DANGER/2);
+            dangerRy1 = normalizedRy1;
+            dangerRy2 = normalizedRy2;
+
         }
         Utils.matToBitmap(frame, bitmap);
         return bitmap;


### PR DESCRIPTION
bed edge를 기반으로 위험 라인을 검출하여 표시합니다.

위험 라인을 넘지 않으면 무게 중심의 색이 녹색
넘으면 노란색
bed edge를 넘으면 검정색이 되도록 설계했으나

위험라인을 아예 넘지 않은 경우를 제외하면 무게중심이 사라져버립니다.

이는 이슈로 따로 올리겠습니다